### PR TITLE
escape html tag after striptags

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -2,7 +2,7 @@
 {% block title %}{{ article.title|striptags }}{% endblock %}
 {% block metadata %}
 
-<meta name="description" content="{{ article.summary|striptags }}">
+<meta name="description" content="{{ article.summary|striptags|escape }}">
 <meta name="keywords" content="{% for tag in article.tags %}{{tag}}{%if not loop.last %},{% endif %}{%endfor%}">
 <meta name="author" content="{% for author in article.authors %}{{author}}{%endfor%}">
 <meta name="robots" content="index,follow">
@@ -12,7 +12,7 @@
 <meta property="og:property" content="{{ DEFAULT_LANG }}">
 <meta property="og:title" content="{{article.title|striptags}}">
 <meta property="og:type" content="article">
-<meta property="og:description" content="{{article.summary|striptags}}">
+<meta property="og:description" content="{{article.summary|striptags|escape}}">
 <meta property="article:published_time" content="{{ article.date.strftime('%Y-%m-%d') }}">
 {%if article.modified%}<meta property="article:modified_time" content="{{ article.modified.strftime('%Y-%m-%d') }}">{%endif%}
 {% for tag in article.tags %}


### PR DESCRIPTION
Hi González,
I think we should put escape after striptags for article.summary and article.content in meta tags.
Because summary of content will contain html tag after strip tag when we show html tag in code block.

For example.

	Here is a bad case.
	```html 
	<script type="text/javascript"
	   src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
	```
